### PR TITLE
Set request Content-Type to application/json

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -29,7 +29,7 @@ var makeRpcRequest = function(options) {
       path: endpoint.path,
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json-rpc',
+        'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(postData, 'utf8')
       }
     };


### PR DESCRIPTION
In order to be compliant with the version 2 of the API.
It is still compatible with the version 1.